### PR TITLE
Pluralize defaults

### DIFF
--- a/__tests__/transCore.test.js
+++ b/__tests__/transCore.test.js
@@ -21,6 +21,14 @@ const nsInterpolate = {
   key_2: 'message 2',
 }
 
+const nsPlural = {
+  key_1: {
+    0: 'No messages',
+    one: '{{count}} message',
+    other: '{{count}} messages',
+  },
+}
+
 describe('transCore', () => {
   test('should return an object of root keys', async () => {
     const t = transCore({
@@ -99,5 +107,22 @@ describe('transCore', () => {
     expect(t('nsInterpolate:.', { count }, { returnObjects: true })).toEqual(
       expected
     )
+  })
+
+  test('should work with pluralization', async () => {
+    const t = transCore({
+      config: {},
+      allNamespaces: { nsObject: nsPlural },
+      pluralRules: {
+        select: (count) => (Math.abs(count) === 1 ? 'one' : 'other'),
+      },
+      lang: 'en',
+    })
+
+    const count = 4
+    const expected = '4 messages'
+
+    expect(typeof t).toBe('function')
+    expect(t('nsObject:key_1', { count })).toEqual(expected)
   })
 })

--- a/__tests__/transCore.test.js
+++ b/__tests__/transCore.test.js
@@ -119,10 +119,19 @@ describe('transCore', () => {
       lang: 'en',
     })
 
-    const count = 4
-    const expected = '4 messages'
+    const oneCount = 1
+    const otherCount = 4
+    const oneExpected = '1 message'
+    const otherExpected = '4 messages'
 
     expect(typeof t).toBe('function')
-    expect(t('nsObject:key_1', { count })).toEqual(expected)
+    expect(t('nsObject:key_1', { count: oneCount })).toEqual(oneExpected)
+    expect(t('nsObject:key_1', { count: otherCount })).toEqual(otherExpected)
+    expect(
+      t('nsObject:key_2', { count: oneCount }, { default: nsPlural.key_1 })
+    ).toEqual(oneExpected)
+    expect(
+      t('nsObject:key_2', { count: otherCount }, { default: nsPlural.key_1 })
+    ).toEqual(otherExpected)
   })
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ export type Translate = <T = string>(
   options?: {
     returnObjects?: boolean
     fallback?: string | string[]
-    default?: string
+    default?: string | Record<string, string>
     ns?: string
   }
 ) => T

--- a/src/transCore.tsx
+++ b/src/transCore.tsx
@@ -7,7 +7,7 @@ import {
 } from '.'
 import { Translate } from './index'
 
-const PLURAL_KEY_REGEX = /^(\n+|zero|one|two|few|many|other)$/
+const PLURAL_KEY_REGEX = /^(\d+|zero|one|two|few|many|other)$/
 
 function splitNsKey(key: string, nsSeparator: string | false) {
   if (!nsSeparator) return { i18nKey: key }

--- a/src/transCore.tsx
+++ b/src/transCore.tsx
@@ -75,6 +75,7 @@ export default function transCore({
       // Use the default value if necessary
       value =
         typeof options.default === 'string' ||
+        typeof options.default?.other !== 'string' ||
         Object.keys(options.default).some((x) => !PLURAL_KEY_REGEX.test(x))
           ? options.default
           : getDicValue(
@@ -82,7 +83,7 @@ export default function transCore({
               pluralRules.select(query?.count || 0),
               config,
               options
-            )
+            ) || options.default.other
     } else if (empty) {
       // no need to try interpolation
       return k

--- a/src/transCore.tsx
+++ b/src/transCore.tsx
@@ -7,6 +7,8 @@ import {
 } from '.'
 import { Translate } from './index'
 
+const PLURAL_KEY_REGEX = /^(\n+|zero|one|two|few|many|other)$/
+
 function splitNsKey(key: string, nsSeparator: string | false) {
   if (!nsSeparator) return { i18nKey: key }
   const i = key.indexOf(nsSeparator)
@@ -70,7 +72,17 @@ export default function transCore({
     }
 
     if (empty && options?.default && fallbacks?.length == 0) {
-      value = options?.default
+      // Use the default value if necessary
+      value =
+        typeof options.default === 'string' ||
+        Object.keys(options.default).some((x) => !PLURAL_KEY_REGEX.test(x))
+          ? options.default
+          : getDicValue(
+              options.default || {},
+              pluralRules.select(query?.count || 0),
+              config,
+              options
+            )
     } else if (empty) {
       // no need to try interpolation
       return k

--- a/src/transCore.tsx
+++ b/src/transCore.tsx
@@ -41,7 +41,7 @@ export default function transCore({
 
     const dic = (namespace && allNamespaces[namespace]) || {}
     const keyWithPlural = plural(pluralRules, dic, i18nKey, config, query)
-    const value = getDicValue(dic, keyWithPlural, config, options)
+    let value = getDicValue(dic, keyWithPlural, config, options)
 
     const empty =
       typeof value === 'undefined' ||
@@ -70,11 +70,9 @@ export default function transCore({
     }
 
     if (empty && options?.default && fallbacks?.length == 0) {
-      return interpolation({ text: options?.default, query, config, lang })
-    }
-
-    // no need to try interpolation
-    if (empty) {
+      value = options?.default
+    } else if (empty) {
+      // no need to try interpolation
       return k
     }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Updated the `t` function to accept a `default` option that is a pluralizable object. If the object passed as the `default` contains an `other` key (and does not contain any keys that are not either in `Intl.PluralRules`, or an integer), then the default is treated as a plural string, and the t function needs to be passed a `count` variable to pluralize correctly.

**Which issue (if any) does this pull request address?**
N/A

**Is there anything you'd like reviewers to focus on?**

The choice to accept a special object by convention, rather than something totally different like an array of suffixed keys, or something else. 