### PR TITLE
fix: 🐛 made webpack plugin recognize _app.js with custom extensions

### DIFF
--- a/src/plugin/loader.ts
+++ b/src/plugin/loader.ts
@@ -61,14 +61,14 @@ export default function loader(rawCode: string) {
   //
   // This way, the only modified file has to be the _app.js.
   if (hasGetInitialPropsOnAppJs) {
-    return pageNoExt === '/_app'
+    return pageNoExt.startsWith('/_app')
       ? templateWithHoc(rawCode, { typescript, hasLoadLocaleFrom })
       : rawCode
   }
 
   // In case the _app does not have getInitialProps, we can add only the
   // I18nProvider to ensure that translations work inside _app.js
-  if (pageNoExt === '/_app') {
+  if (pageNoExt.startsWith('/_app')) {
     return templateWithHoc(rawCode, {
       skipInitialProps: true,
       typescript,


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**
Inside the webpack plugin, changed the comparisons between `pageNoExt` and `'/_app'` to `startsWith`, since there are custom page extensions that makes `pageNoExt` be more than just `/_app` (eg. if the custom extension  `.page.tsx` is used, `pageNoExt` becomes `/_app.page`)

**Which issue (if any) does this pull request address?**
#943

**Is there anything you'd like reviewers to focus on?**
Maybe theres a better way to properly support this? I'm decently sure the custom extensions still can only end in ts/tsx/js/jsx, but I may be missing something. I'm also not sure on the build process for the repo, so any help/guidance would be appreciated!