### PR TITLE
Allow empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ In the configuration file you can use both the configuration that we specified h
 | `revalidate`   | If you want to have a default revalidate on each page we give you the opportunity to do so by passing a number to revalidate. You can still define getStaticProps on a page with a different revalidate amount and override this default override. | `Number` | If you don't define it, by default the pages will have no revalidate.
 | `pagesInDir`   | If you run `next ./my-app` to change where your pages are, you can here define `my-app/pages` so that next-translate can guess where they are. | `String` | If you don't define it, by default the pages will be searched for in the classic places like `pages` and `src/pages`.
 | `localesToIgnore`   | Indicate these locales to ignore when you are prefixing the default locale using a middleware (in Next +12, [learn how to do it](https://nextjs.org/docs/advanced-features/i18n-routing#prefixing-the-default-locale)) | `Array<string>` | `['default']`
+| `allowEmptyStrings`   | Change how translated empty strings should be handled. If omitted or passed as true, it returns an empty string. If passed as false, returns the key name itself (including ns). | `Boolean` | `true`
+
 
 ## 4. API
 

--- a/__tests__/transCore.test.js
+++ b/__tests__/transCore.test.js
@@ -21,6 +21,10 @@ const nsInterpolate = {
   key_2: 'message 2',
 }
 
+const nsWithEmpty = {
+  emptyKey: '',
+}
+
 describe('transCore', () => {
   test('should return an object of root keys', async () => {
     const t = transCore({
@@ -99,5 +103,42 @@ describe('transCore', () => {
     expect(t('nsInterpolate:.', { count }, { returnObjects: true })).toEqual(
       expected
     )
+  })
+
+  test('should return empty string when allowEmptyStrings is passed as true.', async () => {
+    const t = transCore({
+      config: {
+        allowEmptyStrings: true,
+      },
+      allNamespaces: { nsWithEmpty },
+      lang: 'en',
+    })
+
+    expect(typeof t).toBe('function')
+    expect(t('nsWithEmpty:emptyKey')).toEqual('')
+  })
+
+  test.only('should return empty string when allowEmptyStrings is omitted.', async () => {
+    const t = transCore({
+      allNamespaces: { nsWithEmpty },
+      config: {},
+      lang: 'en',
+    })
+
+    expect(typeof t).toBe('function')
+    expect(t('nsWithEmpty:emptyKey')).toEqual('')
+  })
+
+  test('should return the key name when allowEmptyStrings is omit passed as false.', async () => {
+    const t = transCore({
+      config: {
+        allowEmptyStrings: false,
+      },
+      allNamespaces: { nsWithEmpty },
+      lang: 'en',
+    })
+
+    expect(typeof t).toBe('function')
+    expect(t('nsWithEmpty:emptyKey')).toEqual('nsWithEmpty:emptyKey')
   })
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,8 +61,8 @@ export interface I18nConfig {
   pagesInDir?: string
   interpolation?: {
     format?: Function
-    prefix: string
-    suffix: string
+    prefix?: string
+    suffix?: string
   }
   keySeparator?: string | false
   nsSeparator?: string | false

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,12 +61,13 @@ export interface I18nConfig {
   pagesInDir?: string
   interpolation?: {
     format?: Function
-    prefix?: string
-    suffix?: string
+    prefix: string
+    suffix: string
   }
   keySeparator?: string | false
   nsSeparator?: string | false
   defaultNS?: string
+  allowEmptyStrings?: string
 }
 
 export interface LoaderConfig extends I18nConfig {

--- a/src/transCore.tsx
+++ b/src/transCore.tsx
@@ -30,6 +30,12 @@ export default function transCore({
 }): Translate {
   const { logger = missingKeyLogger } = config
 
+  // By default, keys translated to empty strings
+  // are translated to empty strings or fallbacks/default options.
+  // If allowEmptyStrings is passed as false, result is
+  // the key itself.
+  const allowEmptyStrings = config.allowEmptyStrings || true
+
   const t: Translate = (key = '', query, options) => {
     const k = Array.isArray(key) ? key[0] : key
     const { nsSeparator = ':', loggerEnvironment = 'browser' } = config
@@ -45,7 +51,8 @@ export default function transCore({
 
     const empty =
       typeof value === 'undefined' ||
-      (typeof value === 'object' && !Object.keys(value).length)
+      (typeof value === 'object' && !Object.keys(value).length) ||
+      (value === '' && !allowEmptyStrings)
 
     const fallbacks =
       typeof options?.fallback === 'string'


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Option to default untranslated (empty) strings to the key name itself including namespace.
Example: 
```
const translations = { any-namespace: 'my-key': '' }
t('any-namespace:my-key')

// returns "any-namespace:my-key"
```

Check #956 

**Which issue (if any) does this pull request address?**
#956 

**Is there anything you'd like reviewers to focus on?**
