### PR TITLE
Removes explicit type restriction on Translate generic

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,16 +5,7 @@ export interface TranslationQuery {
   [name: string]: any
 }
 
-
-export interface NestedStringObject {
-  [key:string]: string | NestedStringObject | NestedStringArray
-}
-type ValueOrArray<T> = T | ValueOrArray<T>[];
-type NestedStringArray = ValueOrArray<string | NestedStringObject>;
-
-export type TranslateValue = string | NestedStringObject | NestedStringArray
-
-export type Translate = <T extends TranslateValue = string>(
+export type Translate = <T extends unknown = string>(
   i18nKey: string | TemplateStringsArray,
   query?: TranslationQuery | null,
   options?: {

--- a/src/transCore.tsx
+++ b/src/transCore.tsx
@@ -3,7 +3,6 @@ import {
   I18nDictionary,
   LoaderConfig,
   LoggerProps,
-  TranslateValue,
   TranslationQuery,
 } from '.'
 import { Translate } from './index'
@@ -38,9 +37,12 @@ export default function transCore({
     allowEmptyStrings = true,
   } = config
 
-  const interpolateUnknown = (value: TranslateValue, query?: TranslationQuery | null): TranslateValue => {
+  const interpolateUnknown = (
+    value: unknown,
+    query?: TranslationQuery | null
+  ): typeof value => {
     if (Array.isArray(value)) {
-      return value.map(val => interpolateUnknown(val, query));
+      return value.map((val) => interpolateUnknown(val, query))
     }
     if (value instanceof Object) {
       return objectInterpolation({
@@ -124,7 +126,7 @@ function getDicValue(
   options: { returnObjects?: boolean; fallback?: string | string[] } = {
     returnObjects: false,
   }
-): TranslateValue | undefined {
+): unknown | undefined {
   const { keySeparator = '.' } = config || {}
   const keyParts = keySeparator ? key.split(keySeparator) : [key]
 
@@ -148,7 +150,7 @@ function getDicValue(
     typeof value === 'string' ||
     ((value as unknown) instanceof Object && options.returnObjects)
   ) {
-    return value as TranslateValue
+    return value
   }
 
   return undefined


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Removed the explicit type restriction on the `Translate` generic and it was causing type errors with index mismatches. This also fixed the issue of the `string` type not being the default in some cases.

**Which issue (if any) does this pull request address?**
#1012 

**Is there anything you'd like reviewers to focus on?**
It's pretty straight-forward