### PR TITLE
chore(trans): fix Trans component format crash

### DIFF
--- a/src/formatElements.tsx
+++ b/src/formatElements.tsx
@@ -19,6 +19,7 @@ export default function formatElements(
   value: string,
   elements: ReactElement[] | Record<string, ReactElement> = []
 ): string | ReactNode[] {
+  if (!value) return ""
   const parts = value.replace(nlRe, '').split(tagRe)
 
   if (parts.length === 1) return value


### PR DESCRIPTION
The trans component namespace crash

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Prevent formatElements causing runtime crash when `value` is passed not as a string from <Trans /> component missing namespace. I was passing `<Trans i18nKey={t("name")} />` instead of the namespace:string and in development prior to `2.0.2` this would work with a warning. On `2.0.5` it completely crashes instead.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
