### PR TITLE
fix: support spaces when matching tags

### DIFF
--- a/__tests__/formatElements.test.js
+++ b/__tests__/formatElements.test.js
@@ -1,0 +1,55 @@
+import { tagParsingRegex } from '../src/formatElements'
+
+describe('formatElements', () => {
+  describe('tagParsingRegex', () => {
+    it('should match tags in text', () => {
+      const match = 'foo<p>bar</p>baz'.match(tagParsingRegex)
+      expect(match[0]).toBe('<p>bar</p>')
+      expect(match[1]).toBe('p')
+      expect(match[2]).toBe('bar')
+      expect(match[3]).toBe(undefined)
+    })
+    it('should match empty tags', () => {
+      const match = 'foo<p></p>baz'.match(tagParsingRegex)
+      expect(match[0]).toBe('<p></p>')
+      expect(match[1]).toBe('p')
+      expect(match[2]).toBe('')
+      expect(match[3]).toBe(undefined)
+    })
+    it('should match self closing tags without spaces', () => {
+      const match = 'foo<p/>baz'.match(tagParsingRegex)
+      expect(match[0]).toBe('<p/>')
+      expect(match[1]).toBe(undefined)
+      expect(match[2]).toBe(undefined)
+      expect(match[3]).toBe('p')
+    })
+    it('should match self closing tags with spaces', () => {
+      const match = 'foo<p />baz'.match(tagParsingRegex)
+      expect(match[0]).toBe('<p />')
+      expect(match[1]).toBe(undefined)
+      expect(match[2]).toBe(undefined)
+      expect(match[3]).toBe('p')
+    })
+    it('should match first occurrence of a tag when input has several', () => {
+      const match = 'foo<a>bar</a><b>baz</b>'.match(tagParsingRegex)
+      expect(match[0]).toBe('<a>bar</a>')
+      expect(match[1]).toBe('a')
+      expect(match[2]).toBe('bar')
+      expect(match[3]).toBe(undefined)
+    })
+    it('should match first occurrence of a tag when they are nested', () => {
+      const match = 'foo<a>bar<b>baz</b>foobar</a>qux'.match(tagParsingRegex)
+      expect(match[0]).toBe('<a>bar<b>baz</b>foobar</a>')
+      expect(match[1]).toBe('a')
+      expect(match[2]).toBe('bar<b>baz</b>foobar')
+      expect(match[3]).toBe(undefined)
+    })
+    it('should tolerate spaces in regular tags too', () => {
+      const match = 'foo<a >bar</a >baz'.match(tagParsingRegex)
+      expect(match[0]).toBe('<a >bar</a >')
+      expect(match[1]).toBe('a')
+      expect(match[2]).toBe('bar')
+      expect(match[3]).toBe(undefined)
+    })
+  })
+})

--- a/src/formatElements.tsx
+++ b/src/formatElements.tsx
@@ -1,6 +1,7 @@
 import React, { cloneElement, Fragment, ReactElement, ReactNode } from 'react'
 
-const tagRe = /<(\w+)>(.*?)<\/\1>|<(\w+)\/>/
+export const tagParsingRegex = /<(\w+) *>(.*?)<\/\1 *>|<(\w+) *\/>/
+
 const nlRe = /(?:\r\n|\r|\n)/g
 
 function getElements(
@@ -19,7 +20,7 @@ export default function formatElements(
   value: string,
   elements: ReactElement[] | Record<string, ReactElement> = []
 ): string | ReactNode[] {
-  const parts = value.replace(nlRe, '').split(tagRe)
+  const parts = value.replace(nlRe, '').split(tagParsingRegex)
 
   if (parts.length === 1) return value
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Allow empty spaces in tags to replace with components

**Which issue (if any) does this pull request address?**

#1047 

**Is there anything you'd like reviewers to focus on?**

Technically, this doesn't affect stripping out new lines, but my issue would be resolved non the less.
