### PR TITLE
Change peer dependency for React

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "peerDependencies": {
     "next": ">= 13.2.5",
-    "react": "18.0.0"
+    "react": ">= 18.0.0"
   },
   "prettier": {
     "trailingComma": "es5",


### PR DESCRIPTION
Use React 18.0.0 or any version greater as a peer dependency.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[ X ] Other, please explain:

**What changes did you make? (Give an overview)**

In package.json I changed the peer dependency for React to be `>= 18.0.0` to allow for newer versions of React.

**Which issue (if any) does this pull request address?**

If you try to install Next Translate with `npm install next-translate` while having React already added as a dependency with the latest version (`18.2.0`), installation fails because the dependency tree cannot be resolved. It also happens if you are using Next 13.4.3, which has a React dependency of `^18.2.0`. 

**Is there anything you'd like reviewers to focus on?**

Test the current package.json with React 18.2.0  or Next 13.4.3 as an existing dependency.