### PR TITLE
fix: missingKeyLogger case

### DIFF
--- a/__tests__/transCore.test.js
+++ b/__tests__/transCore.test.js
@@ -25,6 +25,10 @@ const nsWithEmpty = {
   emptyKey: '',
 }
 
+const nsConflictWithKeySeparatorKey = {
+  'key likes sentence.': 'message 1 conflict',
+}
+
 describe('transCore', () => {
   test('should return an object of root keys', async () => {
     const t = transCore({
@@ -152,5 +156,18 @@ describe('transCore', () => {
 
     expect(typeof t).toBe('function')
     expect(t('nsWithEmpty:emptyKey')).toEqual('nsWithEmpty:emptyKey')
+  })
+
+  test('should return key string when key conficts with separator and log warning.', () => {
+    const t = transCore({
+      config: {},
+      allNamespaces: { nsConflictWithKeySeparatorKey },
+      lang: 'en',
+    })
+
+    expect(typeof t).toBe('function')
+    expect(t('nsConflictWithKeySeparatorKey:key likes sentence.')).toEqual(
+      'nsConflictWithKeySeparatorKey:key likes sentence.'
+    )
   })
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -96,6 +96,7 @@ export interface LoaderConfig extends I18nConfig {
 export interface LoggerProps {
   namespace: string | undefined
   i18nKey: string
+  isKeyConflictWithKeySeparator?: boolean
 }
 
 export interface I18nLogger {

--- a/src/transCore.tsx
+++ b/src/transCore.tsx
@@ -57,7 +57,11 @@ export default function transCore({
 
   const t: Translate = (key = '', query, options) => {
     const k = Array.isArray(key) ? key[0] : key
-    const { nsSeparator = ':', loggerEnvironment = 'browser' } = config
+    const {
+      nsSeparator = ':',
+      loggerEnvironment = 'browser',
+      keySeparator = '.',
+    } = config
 
     const { i18nKey, namespace = options?.ns ?? config.defaultNS } = splitNsKey(
       k,
@@ -77,6 +81,17 @@ export default function transCore({
       (typeof value === 'object' && !Object.keys(value).length) ||
       (value === '' && !allowEmptyStrings)
 
+    const keyParts = keySeparator
+      ? keyWithPlural.split(keySeparator)
+      : [keyWithPlural]
+
+    const isKeyConflictWithKeySeparator =
+      keyWithPlural === keySeparator && options?.returnObjects
+        ? false
+        : !!keySeparator &&
+          keyWithPlural.includes(keySeparator) &&
+          !keyParts.at(-1)
+
     const fallbacks =
       typeof options?.fallback === 'string'
         ? [options.fallback]
@@ -88,7 +103,7 @@ export default function transCore({
         loggerEnvironment ===
           (typeof window === 'undefined' ? 'node' : 'browser'))
     ) {
-      logger({ namespace, i18nKey })
+      logger({ namespace, i18nKey, isKeyConflictWithKeySeparator })
     }
 
     // Fallbacks
@@ -268,13 +283,24 @@ function objectInterpolation({
   return obj
 }
 
-function missingKeyLogger({ namespace, i18nKey }: LoggerProps): void {
+function missingKeyLogger({
+  namespace,
+  i18nKey,
+  isKeyConflictWithKeySeparator,
+}: LoggerProps): void {
   if (process.env.NODE_ENV === 'production') return
 
   // This means that instead of "ns:value", "value" has been misspelled (without namespace)
   if (!namespace) {
     console.warn(
       `[next-translate] The text "${i18nKey}" has no namespace in front of it.`
+    )
+    return
+  }
+  // This means that key named likes "i am a sentence." will be regarded as nested keys which losts the last part of the key
+  if (isKeyConflictWithKeySeparator) {
+    console.warn(
+      `[next-translate] "${i18nKey}" is missing its last part of the key after key separator.`
     )
     return
   }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
1. background
If the key value is a symbol sentence, it will be warned missing key, and then there are in my file, which makes me confused.
2. reason
it returns undefined in `getDicValue` function because conflicting with the key separator
3. this pr :)

unit tests passed.
![image](https://github.com/aralroca/next-translate/assets/38524716/a8396436-40ed-4ac7-9813-3c2066954b49)

