### PR TITLE
feat: add Paths type for type safety

### DIFF
--- a/examples/with-app-directory/next-translate.d.ts
+++ b/examples/with-app-directory/next-translate.d.ts
@@ -1,0 +1,23 @@
+import type { Paths, I18n, Translate } from 'next-translate'
+
+export interface TranslationsKeys {
+  common: Paths<typeof import('./locales/en/common.json')>
+  home: Paths<typeof import('./locales/en/home.json')>
+}
+
+export interface TypeSafeTranslate<Namespace extends keyof TranslationsKeys>
+  extends Omit<I18n, 't'> {
+  t: {
+    (
+      key: TranslationsKeys[Namespace],
+      ...rest: Tail<Parameters<Translate>>
+    ): string
+    <T extends string>(template: TemplateStringsArray): string
+  }
+}
+
+declare module 'next-translate/useTranslation' {
+  export default function useTranslation<
+    Namespace extends keyof TranslationsKeys
+  >(namespace: Namespace): TypeSafeTranslate<Namespace>
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -187,11 +187,13 @@ type Join<S1, S2> = S1 extends string
 
 // @ts-ignore
 export type Paths<T> = RemovePlural<
+  // @ts-ignore
   {
-    [K in keyof T]: T[K] extends Record<string, unknown>
+    // @ts-ignore
+    [K in Extract<keyof T, string>]: T[K] extends Record<string, unknown>
       ? Join<K, Paths<T[K]>>
       : K
-  }[keyof T]
+  }[Extract<keyof T, string>]
 >
 
 // TODO: Remove this in future versions > 2.0.0

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -143,6 +143,57 @@ declare global {
   }
 }
 
+//////// For type safety (next-translate.d.ts):  ///////////
+/*
+ *
+ * import type { Paths, I18n, Translate } from "next-translate";
+ *
+ * export interface TranslationsKeys {
+ *   common: Paths<typeof import("./locales/en/common.json")>;
+ *   home: Paths<typeof import("./locales/en/home.json")>;
+ * }
+ *
+ * export interface TypeSafeTranslate<Namespace extends keyof TranslationsKeys>
+ *   extends Omit<I18n, "t"> {
+ *   t: {
+ *     (key: TranslationsKeys[Namespace], ...rest: Tail<Parameters<Translate>>): string;
+ *     <T extends string>(template: TemplateStringsArray): string;
+ *   };
+ * }
+ *
+ * declare module "next-translate/useTranslation" {
+ *   export default function useTranslation<
+ *     Namespace extends keyof TranslationsKeys,
+ *   >(namespace: Namespace): TypeSafeTranslate<Namespace>;
+ * }
+ */
+
+type RemovePlural<Key extends string> = Key extends `${infer Prefix}${
+  | '_zero'
+  | '_one'
+  | '_two'
+  | '_few'
+  | '_many'
+  | '_other'
+  | `_${infer Num}`}`
+  ? Prefix
+  : Key
+
+type Join<S1, S2> = S1 extends string
+  ? S2 extends string
+    ? `${S1}.${S2}`
+    : never
+  : never
+
+// @ts-ignore
+export type Paths<T> = RemovePlural<
+  {
+    [K in keyof T]: T[K] extends Record<string, unknown>
+      ? Join<K, Paths<T[K]>>
+      : K
+  }[keyof T]
+>
+
 // TODO: Remove this in future versions > 2.0.0
 function nextTranslate(nextConfig: NextConfig = {}): NextConfig {
   console.log(`


### PR DESCRIPTION
Related with https://github.com/aralroca/next-translate/issues/721

After this feature (adding `Paths`), is possible to define `next-translate.d.ts` like this:

```ts
import type { Paths, I18n, Translate } from 'next-translate'

export interface TranslationsKeys {
  common: Paths<typeof import('./locales/en/common.json')>
  home: Paths<typeof import('./locales/en/home.json')>
}

export interface TypeSafeTranslate<Namespace extends keyof TranslationsKeys>
  extends Omit<I18n, 't'> {
  t: {
    (
      key: TranslationsKeys[Namespace],
      ...rest: Tail<Parameters<Translate>>
    ): string
    <T extends string>(template: TemplateStringsArray): string
  }
}

declare module 'next-translate/useTranslation' {
  export default function useTranslation<
    Namespace extends keyof TranslationsKeys
  >(namespace: Namespace): TypeSafeTranslate<Namespace>
}
```

Then type safety should work:

<img width="472" alt="Screenshot 2023-07-17 at 19 17 13" src="https://github.com/aralroca/next-translate/assets/13313058/e9e505a7-4cc5-41e3-b2e4-b7f27fb2d181">

<img width="282" alt="Screenshot 2023-07-17 at 19 22 00" src="https://github.com/aralroca/next-translate/assets/13313058/616987b4-e49b-4cf2-b511-cdfaba57e1d2">



