### PR TITLE
docs: add missing type to type-safe translations example

### DIFF
--- a/docs/type-safety.md
+++ b/docs/type-safety.md
@@ -5,6 +5,8 @@ To enable type safety consuming translations, you have to add this to the `next-
 ```ts
 import type { Paths, I18n, Translate } from 'next-translate'
 
+type Tail<T> = T extends [unknown, ...infer Rest] ? Rest : never;
+
 export interface TranslationsKeys {
   // Example with "common" and "home" namespaces in "en" (the default language):
   common: Paths<typeof import('./locales/en/common.json')>


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Add the type `Tail` to the type-safe translations example. I copied it from this comment: https://github.com/aralroca/next-translate/issues/721#issuecomment-966859046