### PR TITLE
:alembic: Demonstrate app-dir example not working on 13.5.x: "locale: `service-worker.js`"

### DIFF
--- a/examples/with-app-directory/package.json
+++ b/examples/with-app-directory/package.json
@@ -12,16 +12,16 @@
   "dependencies": {
     "@mdx-js/loader": "2.3.0",
     "@mdx-js/react": "2.3.0",
-    "@next/mdx": "13.5.4",
-    "next": "13.5.4",
+    "@next/mdx": "13.5.6",
+    "next": "13.5.6",
     "next-translate": "link:../../",
     "react": "link:../../node_modules/react",
     "react-dom": "link:../../node_modules/react-dom"
   },
   "devDependencies": {
-    "@next/bundle-analyzer": "13.5.4",
-    "@types/node": "20.8.6",
-    "@types/react": "18.2.28",
+    "@next/bundle-analyzer": "13.5.6",
+    "@types/node": "20.8.7",
+    "@types/react": "18.2.31",
     "next-translate-plugin": "2.6.1",
     "typescript": "5.2.2"
   },

--- a/examples/with-app-directory/package.json
+++ b/examples/with-app-directory/package.json
@@ -12,18 +12,18 @@
   "dependencies": {
     "@mdx-js/loader": "2.3.0",
     "@mdx-js/react": "2.3.0",
-    "@next/mdx": "13.4.7",
-    "next": "13.4.7",
+    "@next/mdx": "13.5.4",
+    "next": "13.5.4",
     "next-translate": "link:../../",
     "react": "link:../../node_modules/react",
     "react-dom": "link:../../node_modules/react-dom"
   },
   "devDependencies": {
-    "@next/bundle-analyzer": "13.4.6",
-    "@types/node": "20.3.1",
-    "@types/react": "18.2.12",
-    "next-translate-plugin": "2.4.4",
-    "typescript": "5.1.3"
+    "@next/bundle-analyzer": "13.5.4",
+    "@types/node": "20.8.6",
+    "@types/react": "18.2.28",
+    "next-translate-plugin": "2.6.1",
+    "typescript": "5.2.2"
   },
   "resolutions": {
     "webpack": "5.11.1"


### PR DESCRIPTION
Getting a 404 instead of anything. Not sure what happens here.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain:

**What changes did you make? (Give an overview)**

Upgraded the app-dir example to the current versions of next-translate and next.

**Which issue (if any) does this pull request address?**

I want to demonstrate, that currently, I can't get the app-directory to work.

If you access for example `http://localhost:3000/en`, it renders a 404 page and prints the following on the terminal:

```logs
next-translate - compiled page: /[lang] - locale: service-worker.js - namespaces: common, home - used loader: server /layout
 ⨯ ../lib/cjs/createTranslation.js (16:21) @ createTranslation
 ⨯ RangeError: Incorrect locale information provided
    at new PluralRules (<anonymous>)
    at createTranslation (../../lib/cjs/createTranslation.js:22:22)
    at useTranslation (../../lib/cjs/useTranslation.js:38:12)
    at RootLayout (./src/app/[lang]/layout.tsx:23:98)
    at stringify (<anonymous>)
  14 |         config: config,
  15 |         allNamespaces: namespaces,
> 16 |         pluralRules: new Intl.PluralRules(ignoreLang ? undefined : lang),
     |                     ^
  17 |         lang: lang,
  18 |     });
  19 |     return { t: (0, wrapTWithDefaultNs_1.default)(t, defaultNS), lang: lang };
 ⨯ ../lib/cjs/createTranslation.js (16:21) @ createTranslation
```

**Is there anything you'd like reviewers to focus on?**

May for example be related to https://github.com/aralroca/next-translate/issues/1142, but https://github.com/aralroca/next-translate-plugin/pull/72 gave me hope this could work again.