### PR TITLE
feat: add support for arrays and pluralization to Trans component

### DIFF
--- a/__tests__/Trans.test.js
+++ b/__tests__/Trans.test.js
@@ -49,6 +49,75 @@ describe('Trans', () => {
       expect(container.textContent).toContain(expected)
     })
 
+    test('should work with arrays', () => {
+      const i18nKey = 'ns:parent.child'
+      const expectedFirstElement = '<strong>First</strong> element 42'
+      const expectedSecondElement = '<strong>Second</strong> element 42'
+      const withSingular = {
+        parent: {
+          child: [
+            '<0>First</0> element {{num}}',
+            '<0>Second</0> element {{num}}',
+          ],
+        },
+      }
+      const { container } = render(
+        <TestEnglish
+          returnObjects
+          namespaces={{ ns: withSingular }}
+          i18nKey={i18nKey}
+          values={{ num: 42 }}
+          components={[<strong />]}
+        />
+      )
+      expect(container.innerHTML).toContain(expectedFirstElement)
+      expect(container.innerHTML).toContain(expectedSecondElement)
+    })
+
+    test('should work with arrays and singulars', () => {
+      const i18nKey = 'ns:withsingular'
+      const expected = '<strong>The number</strong> is one'
+      const withSingular = {
+        withsingular_0: ['<0>The number</0> is ZERO!'],
+        withsingular_one: ['<0>The number</0> is one'],
+        withsingular_other: ['<0>The number</0> is plural'],
+      }
+
+      const { container } = render(
+        <TestEnglish
+          returnObjects
+          namespaces={{ ns: withSingular }}
+          i18nKey={i18nKey}
+          values={{ count: 1 }}
+          components={[<strong />]}
+        />
+      )
+
+      expect(container.innerHTML).toContain(expected)
+    })
+
+    test('should work with arrays and plurals', () => {
+      const i18nKey = 'ns:withsingular'
+      const expected = '<strong>The number</strong> is plural'
+      const withSingular = {
+        withsingular: ['<0>First</0> is not zero'],
+        withsingular_0: ['<0>The number</0> is ZERO!'],
+        withsingular_other: ['<0>The number</0> is plural'],
+      }
+
+      const { container } = render(
+        <TestEnglish
+          returnObjects
+          namespaces={{ ns: withSingular }}
+          i18nKey={i18nKey}
+          values={{ count: 2 }}
+          components={[<strong />]}
+        />
+      )
+
+      expect(container.innerHTML).toContain(expected)
+    })
+
     test('should work with nested keys and custom keySeparator', () => {
       const i18nKey = 'ns:parent_child'
       const expected = 'The number is 42'

--- a/src/Trans.tsx
+++ b/src/Trans.tsx
@@ -16,6 +16,7 @@ export default function Trans({
   fallback,
   defaultTrans,
   ns,
+  returnObjects,
 }: TransProps): any {
   const { t, lang } = useTranslation(ns)
 
@@ -23,11 +24,19 @@ export default function Trans({
    * Memoize the transformation
    */
   const result = useMemo(() => {
-    const text = t<string>(i18nKey, values, { fallback, default: defaultTrans })
+    const text = t<string>(i18nKey, values, {
+      fallback,
+      default: defaultTrans,
+      returnObjects,
+    })
 
     if (!text) return text
 
-    if (!components || components.length === 0) return text
+    if (!components || components.length === 0)
+      return Array.isArray(text) ? text.map((item) => item) : text
+
+    if (Array.isArray(text))
+      return text.map((item) => formatElements(item, components))
 
     return formatElements(text, components)
   }, [i18nKey, values, components, lang]) as string

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,6 +41,7 @@ export interface TransProps {
   fallback?: string | string[]
   defaultTrans?: string
   ns?: string
+  returnObjects?: boolean
 }
 
 export type PageValue = string[] | ((context: object) => string[])


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Improved Trans component usability to allow dealing with array values and pluralization just as the hook does

**Is there anything you'd like reviewers to focus on?**

I'm not convinced by the new parameter `returnObjects` I added to Trans component. Its the same as `useTranslation`.


Please treat this as a first draft. We can discuss better ways of doing this. If it is a desired feature, I'm glad to keep working on it until we are all satisfied with the outcome.