### PR TITLE
feat: add plural form fallbacks

### DIFF
--- a/__tests__/transCore.test.js
+++ b/__tests__/transCore.test.js
@@ -25,6 +25,11 @@ const nsWithEmpty = {
   emptyKey: '',
 }
 
+const nsWithPlurals = {
+  key_one: 'one',
+  key_other: 'other',
+}
+
 describe('transCore', () => {
   test('should return an object of root keys', async () => {
     const t = transCore({
@@ -152,5 +157,27 @@ describe('transCore', () => {
 
     expect(typeof t).toBe('function')
     expect(t('nsWithEmpty:emptyKey')).toEqual('nsWithEmpty:emptyKey')
+  })
+
+  test('should use the plural form fallback', () => {
+    const fallback = 'other'
+    const pluralRules = new Intl.PluralRules('ro')
+
+    const t = transCore({
+      config: {
+        plurals: {
+          fallbackForm: fallback,
+        },
+      },
+      pluralRules,
+      allNamespaces: { nsWithPlurals },
+      lang: 'ro',
+    })
+
+    expect(typeof t).toBe('function')
+    expect(pluralRules.select(1)).toBe('one')
+    expect(t('nsWithPlurals:key', { count: 1 })).toBe('one')
+    expect(pluralRules.select(2)).toBe('few')
+    expect(t('nsWithPlurals:key', { count: 2 })).toBe(fallback) // Uses `other` instead of `few` since `few` doesn't exist as key
   })
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,7 +74,11 @@ export interface I18nConfig extends NextI18nConfig {
   revalidate?: number
   pagesInDir?: string
   interpolation?: {
-    format?: (value: TranslationQuery[string], format: any, lang: string | undefined) => string
+    format?: (
+      value: TranslationQuery[string],
+      format: any,
+      lang: string | undefined
+    ) => string
     prefix?: string
     suffix?: string
   }
@@ -82,6 +86,9 @@ export interface I18nConfig extends NextI18nConfig {
   nsSeparator?: string | false
   defaultNS?: string
   allowEmptyStrings?: boolean
+  plurals?: {
+    fallbackForm?: Intl.LDMLPluralRule
+  }
 }
 
 export interface LoaderConfig extends I18nConfig {

--- a/src/transCore.tsx
+++ b/src/transCore.tsx
@@ -187,7 +187,8 @@ function plural(
   options?: {
     returnObjects?: boolean
     fallback?: string | string[]
-  }
+  },
+  retry = false
 ): string {
   if (!query || typeof query.count !== 'number') return key
 
@@ -206,6 +207,19 @@ function plural(
   const nestedKey = `${key}.${pluralRules.select(query.count)}`
   if (getDicValue(dic, nestedKey, config, options) !== undefined)
     return nestedKey
+
+  if (config.plurals?.fallbackForm && !retry) {
+    const fallbackForm = config.plurals.fallbackForm
+    return plural(
+      Object.assign(pluralRules, { select: () => fallbackForm }),
+      dic,
+      key,
+      config,
+      query,
+      options,
+      true
+    )
+  }
 
   return key
 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Added a new configuration option at `plurals.fallbackForm` to specify a default fallback plural form.

When the source language doesn't utilize all available plural forms, you either have to duplicate keys for the unused forms or risk missing translations when adding a language with additional plural forms. 

For example, Catalan uses *one* and *other*, while Romanian has *one*, *few*, and *other*. This feature allows setting a fallback form (e.g., *other*), ensuring that in this case, *few* resolves to *other*.

**Which issue (if any) does this pull request address?**
N/A

**Is there anything you'd like reviewers to focus on?**
N/A